### PR TITLE
Update and harden multiple data source modules

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -36,7 +36,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -16,11 +16,11 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Install system dependencies
         run: sudo apt-get install -y libcurl4-openssl-dev
@@ -33,7 +33,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     readr,
     jsonlite,
     httr
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.3
 Suggests: 
     knitr,
     rmarkdown,

--- a/R/arnold.R
+++ b/R/arnold.R
@@ -17,7 +17,7 @@ get_arnold <- function(keyword, from_year, to_year, verbose=FALSE) {
     years <- paste0(years, ',"years:', n, '"')
   years <- xml2::url_escape(years)
 
-  # Not includidng all the terms at the end gives a HTTP 400 error
+  # Not including all the terms at the end gives a HTTP 400 error
   page <- 0
   query <- paste0("query=", keyword,
                   "&maxValuesPerFacet=100&highlightPreTag=__ais-highlight__",
@@ -31,7 +31,8 @@ get_arnold <- function(keyword, from_year, to_year, verbose=FALSE) {
 
   response <- request(url, "post", verbose, payload)
   response <- unlist(response, recursive=FALSE)$results
-  if (response$nbHits==0) {
+  num_hits <- response$nbHits
+  if (num_hits==0) {
     return(NULL) # No results?
   }
 
@@ -53,7 +54,15 @@ get_arnold <- function(keyword, from_year, to_year, verbose=FALSE) {
     response <- unlist(response, recursive=FALSE)$results
   }
 
-  do.call(rbind.data.frame, full)
+
+  results <- do.call(rbind.data.frame, full)
+
+  if (nrow(results) < num_hits) {
+    message("Arnold can only return 1,000 results: not all results were loaded")
+  }
+
+  results
+
 }
 
 .standardize_arnold <- function(keywords, from_date, to_date, verbose) {

--- a/R/macarthur.R
+++ b/R/macarthur.R
@@ -7,20 +7,26 @@
 #' macarthur <- get_macarthur("qualitative",
 #' "1999-01-01", "2020-01-01")
 get_macarthur <- function(keyword, from_year, to_year, verbose=FALSE) {
-  url <- "https://searchg2.crownpeak.net/live-macfound-rt/select?"
+  url <- "https://searchg2.crownpeak.net/live-macfound-redesign-rt/select?"
   parameters <- paste0("q=", xml2::url_escape(keyword),
                        "&wt=json&start=0&rows=25494")
 
   # I really don't know what most of this does below, but it was part of the
   # web interface's API query, so I'm leaving it in for now.
-  extra <- paste0("&echoParams=explicit&fl=%2A&defType=edismax",
-  "&fq=custom_s_template%3A%22grant%20detail%22&sort=score%20desc",
+  extra <- paste0("&echoParams=explicit&fl=*&defType=edismax",
+  "&fq=custom_s_template:%22grant%20detail%22&sort=score%20desc",
   "&qf=custom_t_title%20custom_t_description%20custom_t_name")
   #"&indent=true&json.wrf=searchg2_5445608496089546")
 
   query_url <- paste0(url, parameters, extra)
   response <- request(query_url, "get", verbose)
-  response <- jsonlite::fromJSON(response)
+  response <- jsonlite::fromJSON(
+    rawToChar(
+      as.raw(
+        strtoi(response, 16L)
+      )
+    )
+  )
 
   if (response$response$numFound==0) {
     return(NULL)

--- a/R/macarthur.R
+++ b/R/macarthur.R
@@ -21,16 +21,18 @@ get_macarthur <- function(keyword, from_year, to_year, verbose=FALSE) {
   #"&indent=true&json.wrf=searchg2_5445608496089546")
 
   query_url <- paste0(url, parameters, extra)
-  response <- request(query_url, "get", verbose)
-  if (inherits(response, "xml_document")) {
-    return(NULL)  # Got HTML error page instead of JSON
+  if (verbose) message(paste("GET", query_url, "... "), appendLF=FALSE)
+  raw_response <- httr::GET(query_url,
+                            config = httr::config(connecttimeout = 300))
+  if (verbose) {
+    httr::message_for_status(raw_response)
+    message()
   }
+  httr::warn_for_status(raw_response)
+  if (httr::http_error(raw_response)) return(NULL)
+
   response <- jsonlite::fromJSON(
-    rawToChar(
-      as.raw(
-        strtoi(response, 16L)
-      )
-    )
+    httr::content(raw_response, as = "text", encoding = "UTF-8")
   )
 
   if (response$response$numFound==0) {

--- a/R/macarthur.R
+++ b/R/macarthur.R
@@ -4,8 +4,10 @@
 #' @importFrom jsonlite fromJSON
 #' @export
 #' @examples
+#' \dontrun{
 #' macarthur <- get_macarthur("qualitative",
 #' "1999-01-01", "2020-01-01")
+#' }
 get_macarthur <- function(keyword, from_year, to_year, verbose=FALSE) {
   url <- "https://searchg2.crownpeak.net/live-macfound-redesign-rt/select?"
   parameters <- paste0("q=", xml2::url_escape(keyword),
@@ -20,6 +22,9 @@ get_macarthur <- function(keyword, from_year, to_year, verbose=FALSE) {
 
   query_url <- paste0(url, parameters, extra)
   response <- request(query_url, "get", verbose)
+  if (inherits(response, "xml_document")) {
+    return(NULL)  # Got HTML error page instead of JSON
+  }
   response <- jsonlite::fromJSON(
     rawToChar(
       as.raw(

--- a/R/nsf.R
+++ b/R/nsf.R
@@ -41,6 +41,7 @@ get_nsf <- function(keyword, from_date, to_date, verbose=FALSE, cfda=NULL) {
   for (col in output_cols) {
     if (!(col %in% names(df))) df[[col]] <- NA
   }
+  df <- df[, output_cols]
 
   # Max results 25 per request. Do we need to loop the query?
   while (length(api)==25) {
@@ -56,6 +57,7 @@ get_nsf <- function(keyword, from_date, to_date, verbose=FALSE, cfda=NULL) {
     for (col in output_cols) {
       if (!(col %in% names(temp))) temp[[col]] <- NA
     }
+    temp <- temp[, output_cols]
 
     df <- rbind.data.frame(df, temp)
   }

--- a/R/osociety.R
+++ b/R/osociety.R
@@ -11,24 +11,17 @@ get_osociety <- function(keyword, from_year, to_year, verbose=FALSE) {
                   paste(from_year:to_year, collapse="%2C")) # URL escape
 
   url <- paste0(base_url, query)
-  response <- request(url, "get", verbose)
 
-  results <- xml2::xml_find_all(response, "//div[@data-grants-database-single]")
-  if (length(results)==0) {
-    return(NULL) # No results?
-  }
-
-  # Create object to iteratively add pages of results to
+  # Iterate through pages, collecting all results
   all_results <- list()
-
-  # Iterate through pages
   page <- 1
-  while (length(results) > 0) {
+
+  repeat {
     page_url <- paste0(url, '&page=', page)
-
     response <- request(page_url, "get", verbose)
-
     results <- xml2::xml_find_all(response, "//div[@data-grants-database-single]")
+
+    if (length(results) == 0) break
 
     results <- lapply(results, function(entry) {
       institution <- xml2::xml_text(xml2::xml_find_first(entry, ".//h2"))
@@ -66,9 +59,10 @@ get_osociety <- function(keyword, from_year, to_year, verbose=FALSE) {
     all_results <- append(all_results, results)
 
     Sys.sleep(3)
-
     page <- page + 1
   }
+
+  if (length(all_results) == 0) return(NULL)
 
   do.call(rbind.data.frame, all_results)
 }

--- a/R/rsf.R
+++ b/R/rsf.R
@@ -83,8 +83,8 @@ get_rsf <- function(keyword, verbose=FALSE) {
     })
 
     # Separate awardees and institutions into two lists
-    awardees <- paste(sapply(split_results, function(x) x$awardee), collapse = "; ")
-    institutions <- paste(sapply(split_results, function(x) x$institution), collapse = "; ")
+    pi_names <- paste(sapply(split_results, function(x) x$awardee), collapse = "; ")
+    institution <- paste(sapply(split_results, function(x) x$institution), collapse = "; ")
 
     # Get date/amount
     info <- data.frame(
@@ -99,7 +99,7 @@ get_rsf <- function(keyword, verbose=FALSE) {
     # Remove $ and , in amounts (i.e. $1,000,000)
     amount <- gsub("^\\$|,", "", info$value[info$label=="Award Amount: "])
 
-    data.frame(institutions, awardees, year, amount, title, program,
+    data.frame(institution, pi_names, year, amount, title, program,
                id=paste0("RSF", .text_hash(x))) # Return one df line
   })
   df <- do.call(rbind.data.frame, df) # Bind the df lines
@@ -127,7 +127,7 @@ get_rsf <- function(keyword, verbose=FALSE) {
   }
 
   with(raw, data.frame(
-    institution, pi=pi_name, year, start=NA, end=NA, program, amount,
+    institution, pi=pi_names, year, start=NA, end=NA, program, amount,
     id, title, abstract=NA, keyword, source="RSF"
   ))
 }

--- a/R/rsf.R
+++ b/R/rsf.R
@@ -47,11 +47,16 @@ get_rsf <- function(keyword, verbose=FALSE) {
     awarded_scholars_node <- strong_nodes[rvest::html_text(strong_nodes) == "Awarded Scholars: "]
     other_external_scholars_node <- strong_nodes[rvest::html_text(strong_nodes) == "Other External Scholars: "]
 
-    # Function to get siblings until the next strong tag
+    # Get following siblings of a node, stopping at the next <strong> tag
     get_siblings_until_next_strong <- function(node) {
-      siblings <- xml2::xml_siblings(node)
-      siblings <- siblings[which(rvest::html_name(siblings) != "strong")]
-      return(siblings)
+      if (length(node) == 0) return(xml2::xml_nodeset(list()))
+      following <- xml2::xml_find_all(node, "following-sibling::*")
+      result <- list()
+      for (sib in following) {
+        if (rvest::html_name(sib) == "strong") break
+        result <- c(result, list(sib))
+      }
+      xml2::xml_nodeset(result)
     }
 
     # Extract the relevant text underneath the strong tags

--- a/man/get_macarthur.Rd
+++ b/man/get_macarthur.Rd
@@ -22,6 +22,8 @@ a data.frame
 Search MacArthur foundation for awards
 }
 \examples{
+\dontrun{
 macarthur <- get_macarthur("qualitative",
 "1999-01-01", "2020-01-01")
+}
 }

--- a/tests/testthat/test-macarthur.R
+++ b/tests/testthat/test-macarthur.R
@@ -1,6 +1,6 @@
 test_that("MacArthur returns expected result", {
   skip_on_cran()
-  suppressMessages(vcr::use_cassette("macarthur", serialize_with="json", {
+  suppressMessages(vcr::use_cassette("macarthur", serialize_with="json", record="new_episodes", {
     macarthur <-
       .standardize_macarthur("qualitative", "2015-01-01", "2019-01-01",
                              FALSE)

--- a/tests/testthat/test-osociety.R
+++ b/tests/testthat/test-osociety.R
@@ -1,6 +1,6 @@
 test_that("Expected results from Open Society", {
   skip_on_cran()
-  suppressMessages(vcr::use_cassette("osociety", serialize_with="json", {
+  suppressMessages(vcr::use_cassette("osociety", serialize_with="json", record="new_episodes", {
     osociety <- .standardize_osociety("qualitative", "2012-01-01", "2020-01-01",
                                       FALSE)
   }))

--- a/vignettes/awardFindR.Rmd
+++ b/vignettes/awardFindR.Rmd
@@ -29,7 +29,7 @@ str(nsf)
 
 ## Multiple sources and keywords, specific date range
 ```{r, message=FALSE}
-nsf_and_nih <- search_awards(keywords=c("ontological", "audio recordings"), sources=c("nsf", "nih"), from_date="2018-01-01", to_date="2018-02-01")
+nsf_and_nih <- search_awards(keywords=c("ontological", "audio recordings"), sources=c("nsf", "nih"), from_date="2018-01-01", to_date="2018-09-01")
 table(nsf_and_nih$source)
 unique(nsf_and_nih$keyword)
 ```


### PR DESCRIPTION
Updates and hardens multiple data source modules:

- **MacArthur**: Migrate to redesign API endpoint; replace fragile hex decoding with `httr::content(as="text")` + `fromJSON()`; add HTTP error handling (`httr::http_error()` guard); wrap example in `\dontrun{}` to prevent R CMD check failures on transient 404s
- **NSF**: Fix `rbind` column mismatch error by subsetting to expected columns before binding pages — resolves the vignette build failure
- **RSF**: Return complete PI/institution lists; fix `get_siblings_until_next_strong()` to traverse only following siblings (not all siblings) and stop at the next `<strong>` tag; add empty node-set guard for award pages missing scholar sections
- **Open Society**: Add pagination support; fix duplicate first-page request by using a single `repeat` loop
- **Gates**: Add pagination support
- **Arnold**: Add warning when results are maxed out
- **CI**: Update GitHub Actions versions; update vignette date range